### PR TITLE
Fixes lexer integer double read error

### DIFF
--- a/go/lexer/lexer.go
+++ b/go/lexer/lexer.go
@@ -66,7 +66,7 @@ func (l *Lexer) skipWhitespace() {
 func (l *Lexer) NextToken() token.Token {
 	var tok token.Token
 
-	fmt.Printf("l.ch = %c\n", l.ch)
+	fmt.Printf("Current l.ch = %c\n", l.ch)
 
 	l.skipWhitespace()
 
@@ -99,12 +99,14 @@ func (l *Lexer) NextToken() token.Token {
 		} else if isDigit(l.ch) {
 			tok.Literal = l.readNumber()
 			tok.Type = token.INT
+			fmt.Printf("tok = %v\n", tok)
+			return tok
 		} else {
 			tok = newToken(token.ILLEGAL, l.ch)
 		}
 	}
 
-	fmt.Printf("tok = %v\n", tok)
+	fmt.Printf("tok = %v\n\n", tok)
 
 	l.readChar()
 	return tok

--- a/go/lexer/lexer_test.go
+++ b/go/lexer/lexer_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestNextToken(t *testing.T) {
-	input := `let five = 5;;
-						let ten = 10;;
+	input := `let five = 5;
+						let ten = 10;
 
 						let add = fn(x, y) {
 							x + y;


### PR DESCRIPTION
## Fixes lexer integer double read error

### Changes Being Done

- **Found Bug with lexer integer read** When We read the integer in the lexer, we don't immediatly return the token. This causes us to do a additional `l.readChar()`. Thus skipping the next token entirely or the first letter of an identifier.

### Tests

```go

tests := []struct {
	expectedType    token.TokenType
	expectedLiteral string
}{
	{token.LET, "let"},
	{token.IDENT, "five"},
	{token.ASSIGN, "="},
	{token.INT, "5"},
	{token.SEMICOLON, ";"},
	{token.LET, "let"},
	{token.IDENT, "ten"},
	{token.ASSIGN, "="},
	{token.INT, "10"},
	{token.SEMICOLON, ";"},
	{token.LET, "let"},
	{token.IDENT, "add"},
	{token.ASSIGN, "="},
	{token.FUNCTION, "fn"},
	{token.LPAREN, "("},
	{token.IDENT, "x"},
	{token.COMMA, ","},
	{token.IDENT, "y"},
	{token.RPAREN, ")"},
	{token.LBRACE, "{"},
	{token.IDENT, "x"},
	{token.PLUS, "+"},
	{token.IDENT, "y"},
	{token.SEMICOLON, ";"},
	{token.RBRACE, "}"},
	{token.SEMICOLON, ";"},
	{token.LET, "let"},
	{token.IDENT, "result"},
	{token.ASSIGN, "="},
	{token.IDENT, "add"},
	{token.LPAREN, "("},
	{token.IDENT, "five"},
	{token.COMMA, ","},
	{token.IDENT, "ten"},
	{token.RPAREN, ")"},
	{token.SEMICOLON, ";"},
	{token.EOF, ""},
}

```

### Author/Contributor
[@abasnfarah ]
